### PR TITLE
Add basic code for installing flatpakrefs

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -24,17 +24,22 @@ public class Sideload.Application : Gtk.Application {
     public Application () {
         Object (
             application_id: "io.elementary.sideload",
-            flags: ApplicationFlags.FLAGS_NONE
+            flags: ApplicationFlags.HANDLES_OPEN
         );
     }
 
-    protected override void activate () {
+    protected override void open (File[] files, string hint) {
+        if (files.length == 0) {
+            return;
+        }
+
+        var file = files[0];
         if (get_windows ().length () > 0) {
             get_windows ().data.present ();
             return;
         }
 
-        main_window = new MainWindow (this);
+        main_window = new MainWindow (this, file);
         main_window.show_all ();
 
         var quit_action = new SimpleAction ("quit", null);
@@ -49,7 +54,16 @@ public class Sideload.Application : Gtk.Application {
         });
     }
 
+    protected override void activate () {
+
+    }
+
     public static int main (string[] args) {
+        if (args.length < 2) {
+            print ("Usage: %s /path/to/flatpakref\n", args[0]);
+            return 1;
+        }
+
         var app = new Application ();
         return app.run (args);
     }


### PR DESCRIPTION
Actually makes it so when you hit the Install button the .flatpakref installs. For keeping the PR simple, the code is not connected to reflect the state in the UI. Any errors are printed out to the terminal. That will be a thing for another PR.

From now on you need to launch sideload with a second argument being the path to the flatpakref.