### PR TITLE
Move Flatpak installation to a new class

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -13,6 +13,7 @@ executable(
     'src/Views/ProgressView.vala',
     'src/Application.vala',
     'src/MainWindow.vala',
+    'src/FlatpakRefFile.vala',
     dependencies: [
         dependency ('flatpak'),
         dependency ('glib-2.0'),

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -39,7 +39,7 @@ public class Sideload.Application : Gtk.Application {
             return;
         }
 
-        main_window = new MainWindow (this, file);
+        main_window = new MainWindow (this, new FlatpakRefFile (file));
         main_window.show_all ();
 
         var quit_action = new SimpleAction ("quit", null);

--- a/src/FlatpakRefFile.vala
+++ b/src/FlatpakRefFile.vala
@@ -1,0 +1,86 @@
+/*
+* Copyright 2019 elementary, Inc. (https://elementary.io)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public
+* License as published by the Free Software Foundation; either
+* version 3 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA 02110-1301 USA
+*
+*/
+
+public class Sideload.FlatpakRefFile : Object {
+    public File file { get; construct; }
+    private Bytes? bytes = null;
+
+    private static Flatpak.Installation? installation;
+
+    static construct {
+        try {
+            var installations = Flatpak.get_system_installations (null);
+            if (installations.length > 0) {
+                installation = installations[0];
+            }
+
+        } catch (Error e) {
+            warning (e.message);
+        }
+    }
+
+    public FlatpakRefFile (File file) {
+        Object (file: file);
+    }
+
+    private async Bytes get_bytes () throws Error {
+        if (bytes != null) {
+            return bytes;
+        }
+
+        bytes = yield file.load_bytes_async (null, null);
+        return bytes;
+    }
+
+    public async void install (Cancellable cancellable) throws Error {
+        if (installation == null) {
+            throw new IOError.FAILED (_("Did not find suitable Flatpak installation."));
+        }
+
+        try {
+            var bytes = yield get_bytes ();
+            var transaction = new Flatpak.Transaction.for_installation (installation, cancellable);
+            transaction.add_install_flatpakref (bytes);
+            yield run_transaction_async (transaction, cancellable);
+        } catch (Error e) {
+            throw e;
+        }
+    }
+
+    private static async void run_transaction_async (Flatpak.Transaction transaction, Cancellable cancellable) throws Error {
+        Error? transaction_error = null;
+        new Thread<void*> ("install-ref", () => {
+            try {
+                transaction.run (cancellable);
+            } catch (Error e) {
+                transaction_error = e;
+            }
+
+            Idle.add (run_transaction_async.callback);
+            return null;
+        });
+
+        yield;
+
+        if (transaction_error != null) {
+            throw transaction_error;
+        }
+    }    
+}


### PR DESCRIPTION
Just moves stuff to a new class so that it will be easier in the future to extend the backend for new functionality.