### PR TITLE
Show app name and progress

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -98,6 +98,8 @@ public class Sideload.MainWindow : Gtk.ApplicationWindow {
 
         install_button.clicked.connect (on_install_button_clicked);
         cancel_button.clicked.connect (() => cancel ());
+        file.progress_changed.connect (on_progress_changed);
+        get_details.begin ();
     }
 
     protected override bool delete_event (Gdk.EventAny event) {
@@ -113,6 +115,11 @@ public class Sideload.MainWindow : Gtk.ApplicationWindow {
         return false;
     }
 
+    private async void get_details () {
+        string? name = yield file.get_name ();
+        progress_view.app_name = name;
+    }
+
     private void on_install_button_clicked () {
         current_cancellable = new Cancellable ();
         file.install.begin (current_cancellable, (obj, res) => {
@@ -124,6 +131,10 @@ public class Sideload.MainWindow : Gtk.ApplicationWindow {
         });
 
         stack.visible_child = progress_view;
+    }
+
+    private void on_progress_changed (string description, double progress) {
+        progress_view.progress = progress;
     }
 }
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -117,7 +117,9 @@ public class Sideload.MainWindow : Gtk.ApplicationWindow {
 
     private async void get_details () {
         string? name = yield file.get_name ();
-        progress_view.app_name = name;
+        if (name != null) {
+            progress_view.app_name = name;
+        }
     }
 
     private void on_install_button_clicked () {

--- a/src/Views/ProgressView.vala
+++ b/src/Views/ProgressView.vala
@@ -22,13 +22,9 @@ public class Sideload.ProgressView : Gtk.Grid {
     private Gtk.Label primary_label;
     private Gtk.ProgressBar progressbar;
 
-    public string? app_name {
+    public string app_name {
         set {
-            if (value != null) {
-                primary_label.label = _("Installing “%s”").printf (value);
-            } else {
-                primary_label.label = _("Installing…");
-            }
+            primary_label.label = _("Installing “%s”").printf (value);
         }
     }
 
@@ -42,7 +38,7 @@ public class Sideload.ProgressView : Gtk.Grid {
         var image = new Gtk.Image.from_icon_name ("io.elementary.sideload", Gtk.IconSize.DIALOG);
         image.valign = Gtk.Align.START;
 
-        primary_label = new Gtk.Label (null);
+        primary_label = new Gtk.Label ("Installing…");
         primary_label.max_width_chars = 50;
         primary_label.selectable = true;
         primary_label.wrap = true;

--- a/src/Views/ProgressView.vala
+++ b/src/Views/ProgressView.vala
@@ -19,19 +19,38 @@
 */
 
 public class Sideload.ProgressView : Gtk.Grid {
+    private Gtk.Label primary_label;
+    private Gtk.ProgressBar progressbar;
+
+    public string? app_name {
+        set {
+            if (value != null) {
+                primary_label.label = _("Installing “%s”").printf (value);
+            } else {
+                primary_label.label = _("Installing…");
+            }
+        }
+    }
+
+    public double progress {
+        set {
+            progressbar.fraction = value;
+        }
+    }
+
     construct {
         var image = new Gtk.Image.from_icon_name ("io.elementary.sideload", Gtk.IconSize.DIALOG);
         image.valign = Gtk.Align.START;
 
-        var primary_label = new Gtk.Label (_("Installing “%s”").printf ("Example App"));
+        primary_label = new Gtk.Label (null);
         primary_label.max_width_chars = 50;
         primary_label.selectable = true;
         primary_label.wrap = true;
         primary_label.xalign = 0;
         primary_label.get_style_context ().add_class (Granite.STYLE_CLASS_PRIMARY_LABEL);
 
-        var progressbar = new Gtk.ProgressBar ();
-        progressbar.fraction = 0.1;
+        progressbar = new Gtk.ProgressBar ();
+        progressbar.fraction = 0.0;
         progressbar.hexpand = true;
 
         var cancel_button = new Gtk.Button.with_label (_("Cancel"));


### PR DESCRIPTION
This makes it so when you install a ref, the progress view shows the actual progress and the "Installing" label contains the ref name (will have to figure out if there isn't a better source for the name).

Getting the ref name involves reading the file and creating a KeyFile which is done async. If this fails the label defaults to just `Installing…`.