### PR TITLE
Throw a dialog when installation fails

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -10,6 +10,7 @@ add_project_arguments(['--vapidir', vapi_dir], language: 'vala')
 
 executable(
     meson.project_name(),
+    'src/Dialogs/InstallFailDialog.vala',
     'src/Views/ProgressView.vala',
     'src/Application.vala',
     'src/MainWindow.vala',

--- a/src/Dialogs/InstallFailDialog.vala
+++ b/src/Dialogs/InstallFailDialog.vala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 elementary, Inc. (https://elementary.io)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+public class InstallFailDialog : Granite.MessageDialog {
+    public GLib.Error error { get; construct; }
+    public InstallFailDialog ( GLib.Error e) {
+        Object (
+            title: "",
+            primary_text: _("Install failed"),
+            secondary_text: prettify_flatpak_error (e),
+            buttons: Gtk.ButtonsType.CLOSE,
+            image_icon: new ThemedIcon ("dialog-error"),
+            window_position: Gtk.WindowPosition.CENTER,
+            error: e
+        );
+    }
+
+    construct {
+        response.connect (() => destroy ());
+
+        show_error_details (error.message);
+        stick ();
+    }
+
+    private static string prettify_flatpak_error (GLib.Error e) {
+        if (e is Flatpak.Error.ALREADY_INSTALLED) {
+            return _("This package is already installed.");
+        }
+
+        if (e is Flatpak.Error.NEED_NEW_FLATPAK) {
+            return _("A newer version of flatpak is needed to install this package.");
+        }
+
+        if (e is Flatpak.Error.REMOTE_NOT_FOUND) {
+            return _("A required remote was not found.");
+        }
+
+        if (e is Flatpak.Error.RUNTIME_NOT_FOUND) {
+            return _("A required runtime dependency could not be found.");
+        }
+
+        if (e is Flatpak.Error.INVALID_REF) {
+            return _("The supplied .flatpakref file does not seem to be valid.");
+        }
+
+        if (e is Flatpak.Error.UNTRUSTED) {
+            return _("The package is not signed with a trusted signature.");
+        }
+
+        if (e is Flatpak.Error.INVALID_NAME) {
+            return _("The application, runtime or remote name is invalid");
+        }
+
+        return _("An unknown error occured");
+    }
+}

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -99,6 +99,7 @@ public class Sideload.MainWindow : Gtk.ApplicationWindow {
         install_button.clicked.connect (on_install_button_clicked);
         cancel_button.clicked.connect (() => cancel ());
         file.progress_changed.connect (on_progress_changed);
+        file.installation_failed.connect (on_install_failed);
         get_details.begin ();
     }
 
@@ -124,18 +125,18 @@ public class Sideload.MainWindow : Gtk.ApplicationWindow {
 
     private void on_install_button_clicked () {
         current_cancellable = new Cancellable ();
-        file.install.begin (current_cancellable, (obj, res) => {
-            try {
-                file.install.end (res);
-            } catch (Error e) {
-                warning (e.message);
-            }
-        });
-
+        file.install.begin (current_cancellable);
         stack.visible_child = progress_view;
     }
 
     private void on_progress_changed (string description, double progress) {
         progress_view.progress = progress;
+    }
+
+    private void on_install_failed (GLib.Error e) {
+        var dialog = new InstallFailDialog (e);
+        dialog.destroy.connect (() => destroy ());
+        dialog.present ();
+        hide ();
     }
 }

--- a/vapi/flatpak.vapi
+++ b/vapi/flatpak.vapi
@@ -241,7 +241,7 @@ namespace Flatpak {
 		public virtual signal void end_of_lifed (string @ref, string reason, string rebase);
 		public virtual signal void new_operation (Flatpak.TransactionOperation operation, Flatpak.TransactionProgress progress);
 		public virtual signal void operation_done (Flatpak.TransactionOperation operation, string commit, int details);
-		public virtual signal bool operation_error (Flatpak.TransactionOperation operation, GLib.Error error, int detail);
+		public virtual signal bool operation_error (Flatpak.TransactionOperation operation, GLib.Error error, TransactionErrorDetails detail);
 		public virtual signal bool ready ();
 	}
 	[CCode (cheader_filename = "flatpak.h", type_id = "flatpak_transaction_operation_get_type ()")]
@@ -295,10 +295,10 @@ namespace Flatpak {
 		MMC,
 		NETWORK
 	}
-	[CCode (cheader_filename = "flatpak.h", cprefix = "FLATPAK_TRANSACTION_ERROR_DETAILS_NON_", type_id = "flatpak_transaction_error_details_get_type ()")]
+	[CCode (cheader_filename = "flatpak.h", cprefix = "FLATPAK_TRANSACTION_ERROR_DETAILS_", type_id = "flatpak_transaction_error_details_get_type ()")]
 	[Flags]
 	public enum TransactionErrorDetails {
-		FATAL
+		NON_FATAL
 	}
 	[CCode (cheader_filename = "flatpak.h", cprefix = "FLATPAK_TRANSACTION_OPERATION_", type_id = "flatpak_transaction_operation_type_get_type ()")]
 	public enum TransactionOperationType {


### PR DESCRIPTION
I opted for a `MessageDialog` when a failure happens as some of the Flatpak errors can be quite verbose, so we can opt to show them in the terminal style revealer.