### PR TITLE
Automatically select remote for dependency

### DIFF
--- a/src/FlatpakRefFile.vala
+++ b/src/FlatpakRefFile.vala
@@ -91,6 +91,17 @@ public class Sideload.FlatpakRefFile : Object {
             var transaction = new Flatpak.Transaction.for_installation (installation, cancellable);
             transaction.add_install_flatpakref (bytes);
             transaction.new_operation.connect ((operation, progress) => on_new_operation (operation, progress, cancellable));
+
+            // Automatically select the first available remote thas has the dependency we need to install
+            transaction.choose_remote_for_ref.connect ((@ref, runtime_ref, remotes) => {
+                // TODO: Possibly be more clever here, but this currently matches AppCenter & GNOME software
+                if (remotes.length > 0) {
+                    return 0;
+                } else {
+                    return -1;
+                }
+            });
+
             yield run_transaction_async (transaction, cancellable);
         } catch (Error e) {
             throw e;


### PR DESCRIPTION
This allows sideload to automatically select a configured remote to install a dependency from. This is currently how AppCenter and GNOME software do this. It does the job, but it feels like it could be smarter.