### PR TITLE
Get app store name from appstream url handler

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -71,7 +71,7 @@ public class Sideload.Application : Gtk.Application {
         if (appinfo != null) {
             return appinfo.get_name ();
         } else {
-            return _("AppCenter");
+            return _("your software center");
         }
     }
 

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -66,6 +66,15 @@ public class Sideload.Application : Gtk.Application {
 
     }
 
+    public unowned string get_appstore_name () {
+        var appinfo = GLib.AppInfo.get_default_for_uri_scheme ("appstream://");
+        if (appinfo != null) {
+            return appinfo.get_name ();
+        } else {
+            return _("AppCenter");
+        }
+    }
+
     public static int main (string[] args) {
         if (args.length < 2) {
             print ("Usage: %s /path/to/flatpakref\n", args[0]);

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -66,8 +66,8 @@ public class Sideload.Application : Gtk.Application {
 
     }
 
-    public unowned string get_appstore_name () {
-        var appinfo = GLib.AppInfo.get_default_for_uri_scheme ("appstream://");
+    public string get_appstore_name () {
+        var appinfo = GLib.AppInfo.get_default_for_uri_scheme ("appstream");
         if (appinfo != null) {
             return appinfo.get_name ();
         } else {

--- a/src/Views/MainView.vala
+++ b/src/Views/MainView.vala
@@ -125,7 +125,9 @@ public class Sideload.MainView : AbstractView {
             repo_context.add_class ("appcenter");
             repo_context.add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
-            var repo_label = new Gtk.Label (_("Other apps from this distributor may appear in AppCenter"));
+            var appstore_name = ((Sideload.Application) GLib.Application.get_default ()).get_appstore_name ();
+
+            var repo_label = new Gtk.Label (_("Other apps from this distributor may appear in %s").printf (appstore_name));
             repo_label.selectable = true;
             repo_label.max_width_chars = 50;
             repo_label.wrap = true;

--- a/src/Views/SuccessView.vala
+++ b/src/Views/SuccessView.vala
@@ -30,12 +30,14 @@ public class Sideload.SuccessView : AbstractView {
     construct {
         badge.gicon = new ThemedIcon ("process-completed");
 
+        var appstore_name = ((Sideload.Application) GLib.Application.get_default ()).get_appstore_name ();
+
         if (view_type == SuccessType.INSTALLED) {
             primary_label.label = _("The app has been installed");
-            secondary_label.label = _("Open it any time from the Applications Menu. Visit AppCenter for app information, updates, and to uninstall.");
+            secondary_label.label = _("Open it any time from the Applications Menu. Visit %s for app information, updates, and to uninstall.").printf (appstore_name);
         } else if (view_type == SuccessType.ALREADY_INSTALLED) {
             primary_label.label = _("App already installed");
-            secondary_label.label = _("No changes were made. Visit AppCenter for app information, updates, and to uninstall.");
+            secondary_label.label = _("No changes were made. Visit %s for app information, updates, and to uninstall.").printf (appstore_name);
         }
 
         var close_button = new Gtk.Button.with_label (_("Close"));


### PR DESCRIPTION
Fixes #46 

As discussed in Slack, this is probably the best/closest way to find out the name of the app store on a system.

It's likely that if a distribution is shipping this app, they're also shipping an app store that handles flatpak