### PR TITLE
deb-packaging: Depend on flatpak

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,6 +12,6 @@ Standards-Version: 4.1.1
 
 Package: io.elementary.sideload
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}
+Depends: ${misc:Depends}, ${shlibs:Depends}, flatpak
 Description: Install apps downloaded from the Internet
  Sideload is a stand-alone Flatpak installer


### PR DESCRIPTION
Fixes #64

Also means that when we add Sideload to the seeds, we'll pull flatpak as a dependency too.