### PR TITLE
Update flatpak vapi and simplify download size calculation

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -27,7 +27,7 @@ executable(
     'src/MainWindow.vala',
     'src/FlatpakRefFile.vala',
     dependencies: [
-        dependency ('flatpak'),
+        dependency ('flatpak', version: '>=1.1.2'),
         dependency ('glib-2.0'),
         dependency ('gobject-2.0'),
         dependency ('granite', version: '>=0.5'),

--- a/src/FlatpakRefFile.vala
+++ b/src/FlatpakRefFile.vala
@@ -172,13 +172,6 @@ public class Sideload.FlatpakRefFile : Object {
                 operations.foreach ((entry) => {
                     try {
                         var @ref = Flatpak.Ref.parse (entry.get_ref ());
-                        var remote_ref = installation.fetch_remote_ref_sync (
-                            entry.get_remote (),
-                            @ref.kind,
-                            @ref.name,
-                            @ref.arch,
-                            @ref.branch,
-                            cancellable);
 
                         // If this is the ref the user requested to install, download the appdata for its remote
                         if (@ref.name == flatpakref_id) {
@@ -192,7 +185,7 @@ public class Sideload.FlatpakRefFile : Object {
                             }
                         }
 
-                        total_download_size += remote_ref.download_size;
+                        total_download_size += entry.get_download_size ();
                     } catch (Error e) {
                         warning ("Error calculating download size: %s", e.message);
                     }

--- a/vapi/flatpak.vapi
+++ b/vapi/flatpak.vapi
@@ -20,12 +20,16 @@ namespace Flatpak {
 	public class Installation : GLib.Object {
 		[CCode (has_construct_function = false)]
 		protected Installation ();
+		[Version (since = "1.3.4")]
+		public bool add_remote (Flatpak.Remote remote, bool if_needed, GLib.Cancellable? cancellable = null) throws GLib.Error;
 		[Version (since = "0.10.0")]
 		public bool cleanup_local_refs_sync (GLib.Cancellable? cancellable = null) throws GLib.Error;
 		public GLib.FileMonitor create_monitor (GLib.Cancellable? cancellable = null) throws GLib.Error;
 		public bool drop_caches (GLib.Cancellable? cancellable = null) throws GLib.Error;
 		public GLib.Bytes fetch_remote_metadata_sync (string remote_name, Flatpak.Ref @ref, GLib.Cancellable? cancellable = null) throws GLib.Error;
 		public Flatpak.RemoteRef fetch_remote_ref_sync (string remote_name, Flatpak.RefKind kind, string name, string? arch, string? branch, GLib.Cancellable? cancellable = null) throws GLib.Error;
+		[Version (since = "1.3.3")]
+		public Flatpak.RemoteRef fetch_remote_ref_sync_full (string remote_name, Flatpak.RefKind kind, string name, string? arch, string? branch, Flatpak.QueryFlags flags, GLib.Cancellable? cancellable = null) throws GLib.Error;
 		public bool fetch_remote_size_sync (string remote_name, Flatpak.Ref @ref, out uint64 download_size, out uint64 installed_size, GLib.Cancellable? cancellable = null) throws GLib.Error;
 		[CCode (has_construct_function = false)]
 		public Installation.for_path (GLib.File path, bool user, GLib.Cancellable? cancellable = null) throws GLib.Error;
@@ -37,6 +41,9 @@ namespace Flatpak {
 		public unowned string get_id ();
 		public Flatpak.InstalledRef get_installed_ref (Flatpak.RefKind kind, string name, string? arch, string? branch, GLib.Cancellable? cancellable = null) throws GLib.Error;
 		public bool get_is_user ();
+		[Version (since = "1.1")]
+		public bool get_min_free_space_bytes (out uint64 out_bytes) throws GLib.Error;
+		public bool get_no_interaction ();
 		public GLib.File get_path ();
 		[Version (since = "0.8")]
 		public int get_priority ();
@@ -49,16 +56,22 @@ namespace Flatpak {
 		[Version (since = "0.6.10")]
 		public Flatpak.RemoteRef install_ref_file (GLib.Bytes ref_file_data, GLib.Cancellable? cancellable = null) throws GLib.Error;
 		public bool launch (string name, string? arch, string? branch, string? commit, GLib.Cancellable? cancellable = null) throws GLib.Error;
+		[Version (since = "1.1")]
+		public bool launch_full (Flatpak.LaunchFlags flags, string name, string? arch, string? branch, string? commit, Flatpak.Instance? instance_out, GLib.Cancellable? cancellable = null) throws GLib.Error;
 		public GLib.GenericArray<weak Flatpak.InstalledRef> list_installed_refs (GLib.Cancellable? cancellable = null) throws GLib.Error;
 		public GLib.GenericArray<weak Flatpak.InstalledRef> list_installed_refs_by_kind (Flatpak.RefKind kind, GLib.Cancellable? cancellable = null) throws GLib.Error;
 		public GLib.GenericArray<weak Flatpak.InstalledRef> list_installed_refs_for_update (GLib.Cancellable? cancellable = null) throws GLib.Error;
 		[Version (since = "0.6.7")]
 		public GLib.GenericArray<weak Flatpak.RelatedRef> list_installed_related_refs_sync (string remote_name, string @ref, GLib.Cancellable? cancellable = null) throws GLib.Error;
 		public GLib.GenericArray<weak Flatpak.RemoteRef> list_remote_refs_sync (string remote_or_uri, GLib.Cancellable? cancellable = null) throws GLib.Error;
+		[Version (since = "1.3.3")]
+		public GLib.GenericArray<weak Flatpak.RemoteRef> list_remote_refs_sync_full (string remote_or_uri, Flatpak.QueryFlags flags, GLib.Cancellable? cancellable = null) throws GLib.Error;
 		[Version (since = "0.6.7")]
 		public GLib.GenericArray<weak Flatpak.RelatedRef> list_remote_related_refs_sync (string remote_name, string @ref, GLib.Cancellable? cancellable = null) throws GLib.Error;
 		public GLib.GenericArray<weak Flatpak.Remote> list_remotes (GLib.Cancellable? cancellable = null) throws GLib.Error;
 		public GLib.GenericArray<weak Flatpak.Remote> list_remotes_by_type ([CCode (array_length_cname = "num_types", array_length_pos = 1.5, array_length_type = "gsize")] Flatpak.RemoteType[] types, GLib.Cancellable? cancellable = null) throws GLib.Error;
+		[Version (since = "1.1.2")]
+		public GLib.GenericArray<weak Flatpak.InstalledRef> list_unused_refs (string? arch, GLib.Cancellable? cancellable = null) throws GLib.Error;
 		public string load_app_overrides (string app_id, GLib.Cancellable? cancellable = null) throws GLib.Error;
 		public bool modify_remote (Flatpak.Remote remote, GLib.Cancellable? cancellable = null) throws GLib.Error;
 		[Version (since = "0.10.0")]
@@ -69,6 +82,8 @@ namespace Flatpak {
 		[Version (since = "1.0.3")]
 		public bool run_triggers (GLib.Cancellable? cancellable = null) throws GLib.Error;
 		public bool set_config_sync (string key, string value, GLib.Cancellable? cancellable = null) throws GLib.Error;
+		[Version (since = "1.1.1")]
+		public void set_no_interaction (bool no_interaction);
 		[CCode (has_construct_function = false)]
 		public Installation.system (GLib.Cancellable? cancellable = null) throws GLib.Error;
 		[CCode (has_construct_function = false)]
@@ -78,7 +93,7 @@ namespace Flatpak {
 		[Version (since = "0.11.8")]
 		public bool uninstall_full (Flatpak.UninstallFlags flags, Flatpak.RefKind kind, string name, string? arch, string? branch, GLib.Cancellable? cancellable = null) throws GLib.Error;
 		public Flatpak.InstalledRef update (Flatpak.UpdateFlags flags, Flatpak.RefKind kind, string name, string? arch, string? branch, ProgressCallback cb, GLib.Cancellable? cancellable = null) throws GLib.Error;
-		public bool update_appstream_full_sync (string remote_name, string arch, bool? out_changed, GLib.Cancellable? cancellable = null) throws GLib.Error;
+		public bool update_appstream_full_sync (string remote_name, string? arch, bool? out_changed, GLib.Cancellable? cancellable = null) throws GLib.Error;
 		public bool update_appstream_sync (string remote_name, string? arch, bool? out_changed, GLib.Cancellable? cancellable = null) throws GLib.Error;
 		public Flatpak.InstalledRef update_full (Flatpak.UpdateFlags flags, Flatpak.RefKind kind, string name, string? arch, string? branch, [CCode (array_length = false, array_null_terminated = true)] string[]? subpaths, GLib.Cancellable? cancellable = null) throws GLib.Error;
 		[Version (since = "0.6.13")]
@@ -90,16 +105,30 @@ namespace Flatpak {
 	public class InstalledRef : Flatpak.Ref {
 		[CCode (has_construct_function = false)]
 		protected InstalledRef ();
+		[Version (since = "1.1.2")]
+		public unowned string get_appdata_license ();
+		[Version (since = "1.1.2")]
+		public unowned string get_appdata_name ();
+		[Version (since = "1.1.2")]
+		public unowned string get_appdata_summary ();
+		[Version (since = "1.1.2")]
+		public unowned string get_appdata_version ();
 		public unowned string get_deploy_dir ();
 		public unowned string get_eol ();
 		public unowned string get_eol_rebase ();
 		public uint64 get_installed_size ();
 		public bool get_is_current ();
-		public unowned string get_latest_commit ();
+		public unowned string? get_latest_commit ();
 		public unowned string get_origin ();
 		[CCode (array_length = false, array_null_terminated = true)]
 		public unowned string[] get_subpaths ();
+		[Version (since = "1.1.2")]
+		public GLib.Bytes load_appdata (GLib.Cancellable? cancellable = null) throws GLib.Error;
 		public GLib.Bytes load_metadata (GLib.Cancellable? cancellable = null) throws GLib.Error;
+		public string appdata_license { get; construct; }
+		public string appdata_name { get; construct; }
+		public string appdata_summary { get; construct; }
+		public string appdata_version { get; construct; }
 		[NoAccessorMethod]
 		public string deploy_dir { owned get; set; }
 		[NoAccessorMethod]
@@ -117,6 +146,34 @@ namespace Flatpak {
 		[CCode (array_length = false, array_null_terminated = true)]
 		[NoAccessorMethod]
 		public string[] subpaths { owned get; set; }
+	}
+	[CCode (cheader_filename = "flatpak.h", type_id = "flatpak_instance_get_type ()")]
+	public class Instance : GLib.Object {
+		[CCode (has_construct_function = false)]
+		protected Instance ();
+		[Version (since = "1.1")]
+		public static GLib.GenericArray<Flatpak.Instance> get_all ();
+		[Version (since = "1.1")]
+		public unowned string get_app ();
+		[Version (since = "1.1")]
+		public unowned string get_arch ();
+		[Version (since = "1.1")]
+		public unowned string get_branch ();
+		[Version (since = "1.1")]
+		public int get_child_pid ();
+		[Version (since = "1.1")]
+		public unowned string get_commit ();
+		[Version (since = "1.1")]
+		public unowned string get_id ();
+		[Version (since = "1.1")]
+		public GLib.KeyFile get_info ();
+		[Version (since = "1.1")]
+		public int get_pid ();
+		[Version (since = "1.1")]
+		public unowned string get_runtime ();
+		[Version (since = "1.1")]
+		public unowned string get_runtime_commit ();
+		public bool is_running ();
 	}
 	[CCode (cheader_filename = "flatpak.h", type_id = "flatpak_ref_get_type ()")]
 	public class Ref : GLib.Object {
@@ -157,13 +214,28 @@ namespace Flatpak {
 	public class Remote : GLib.Object {
 		[CCode (has_construct_function = false)]
 		public Remote (string name);
+		[CCode (has_construct_function = false)]
+		[Version (since = "1.3.4")]
+		public Remote.from_file (string name, GLib.Bytes data) throws GLib.Error;
 		public GLib.File get_appstream_dir (string? arch);
 		public GLib.File get_appstream_timestamp (string? arch);
 		public string? get_collection_id ();
+		[Version (since = "1.4")]
+		public string get_comment ();
 		[Version (since = "0.6.12")]
 		public string get_default_branch ();
+		[Version (since = "1.4")]
+		public string get_description ();
 		public bool get_disabled ();
+		[Version (since = "1.4")]
+		public string get_filter ();
 		public bool get_gpg_verify ();
+		[Version (since = "1.4")]
+		public string get_homepage ();
+		[Version (since = "1.4")]
+		public string get_icon ();
+		[Version (since = "1.1.1")]
+		public string get_main_ref ();
 		public unowned string get_name ();
 		public bool get_nodeps ();
 		public bool get_noenumerate ();
@@ -173,11 +245,23 @@ namespace Flatpak {
 		public string get_title ();
 		public string get_url ();
 		public void set_collection_id (string? collection_id);
+		[Version (since = "1.4")]
+		public void set_comment (string comment);
 		[Version (since = "0.6.12")]
 		public void set_default_branch (string default_branch);
+		[Version (since = "1.4")]
+		public void set_description (string description);
 		public void set_disabled (bool disabled);
+		[Version (since = "1.4")]
+		public void set_filter (string filter_path);
 		public void set_gpg_key (GLib.Bytes gpg_key);
 		public void set_gpg_verify (bool gpg_verify);
+		[Version (since = "1.4")]
+		public void set_homepage (string homepage);
+		[Version (since = "1.4")]
+		public void set_icon (string icon);
+		[Version (since = "1.1.1")]
+		public void set_main_ref (string main_ref);
 		public void set_nodeps (bool nodeps);
 		public void set_noenumerate (bool noenumerate);
 		public void set_prio (int prio);
@@ -217,6 +301,8 @@ namespace Flatpak {
 		public bool add_install (string remote, string @ref, [CCode (array_length = false, array_null_terminated = true)] string[]? subpaths) throws GLib.Error;
 		public bool add_install_bundle (GLib.File file, GLib.Bytes? gpg_data) throws GLib.Error;
 		public bool add_install_flatpakref (GLib.Bytes flatpakref_data) throws GLib.Error;
+		[Version (since = "1.3.3.")]
+		public bool add_rebase (string remote, string @ref, string subpaths, [CCode (array_length = false, array_null_terminated = true)] string[]? previous_ids) throws GLib.Error;
 		public bool add_uninstall (string @ref) throws GLib.Error;
 		public bool add_update (string @ref, [CCode (array_length = false, array_null_terminated = true)] string[]? subpaths, string? commit) throws GLib.Error;
 		[CCode (has_construct_function = false)]
@@ -225,7 +311,7 @@ namespace Flatpak {
 		public Flatpak.Installation get_installation ();
 		public GLib.List<Flatpak.TransactionOperation> get_operations ();
 		public bool is_empty ();
-		public bool run (GLib.Cancellable? cancellable = null) throws GLib.Error;
+		public virtual bool run (GLib.Cancellable? cancellable = null) throws GLib.Error;
 		public void set_default_arch (string arch);
 		public void set_disable_dependencies (bool disable_dependencies);
 		public void set_disable_prune (bool disable_prune);
@@ -239,6 +325,7 @@ namespace Flatpak {
 		public virtual signal bool add_new_remote (TransactionRemoteReason reason, string from_id, string remote_name, string url);
 		public virtual signal int choose_remote_for_ref (string for_ref, string runtime_ref, [CCode (array_length = false, array_null_terminated = true)] string[] remotes);
 		public virtual signal void end_of_lifed (string @ref, string reason, string rebase);
+		public virtual signal bool end_of_lifed_with_rebase (string remote, string @ref, string reason, string rebased_to_ref, [CCode (array_length = false, array_null_terminated = true)] string[] previous_ids);
 		public virtual signal void new_operation (Flatpak.TransactionOperation operation, Flatpak.TransactionProgress progress);
 		public virtual signal void operation_done (Flatpak.TransactionOperation operation, string commit, int details);
 		public virtual signal bool operation_error (Flatpak.TransactionOperation operation, GLib.Error error, TransactionErrorDetails detail);
@@ -250,6 +337,10 @@ namespace Flatpak {
 		protected TransactionOperation ();
 		public unowned GLib.File get_bundle_path ();
 		public unowned string get_commit ();
+		[Version (since = "1.1.2")]
+		public uint64 get_download_size ();
+		[Version (since = "1.1.2")]
+		public uint64 get_installed_size ();
 		public unowned GLib.KeyFile get_metadata ();
 		public unowned GLib.KeyFile get_old_metadata ();
 		public Flatpak.TransactionOperationType get_operation_type ();
@@ -260,8 +351,12 @@ namespace Flatpak {
 	public class TransactionProgress : GLib.Object {
 		[CCode (has_construct_function = false)]
 		protected TransactionProgress ();
+		[Version (since = "1.1.2")]
+		public uint64 get_bytes_transferred ();
 		public bool get_is_estimating ();
 		public int get_progress ();
+		[Version (since = "1.1.2")]
+		public uint64 get_start_time ();
 		public unowned string get_status ();
 		public void set_update_frequency (uint update_frequency);
 		public signal void changed ();
@@ -274,6 +369,19 @@ namespace Flatpak {
 		NO_DEPLOY,
 		NO_PULL,
 		NO_TRIGGERS
+	}
+	[CCode (cheader_filename = "flatpak.h", cprefix = "FLATPAK_LAUNCH_FLAGS_", type_id = "flatpak_launch_flags_get_type ()")]
+	[Flags]
+	public enum LaunchFlags {
+		NONE,
+		DO_NOT_REAP
+	}
+	[CCode (cheader_filename = "flatpak.h", cprefix = "FLATPAK_QUERY_FLAGS_", type_id = "flatpak_query_flags_get_type ()")]
+	[Flags]
+	[Version (since = "1.3.3")]
+	public enum QueryFlags {
+		NONE,
+		ONLY_CACHED
 	}
 	[CCode (cheader_filename = "flatpak.h", cprefix = "FLATPAK_REF_KIND_", type_id = "flatpak_ref_kind_get_type ()")]
 	public enum RefKind {
@@ -356,7 +464,11 @@ namespace Flatpak {
 		EXPORT_FAILED,
 		REMOTE_USED,
 		RUNTIME_USED,
-		INVALID_NAME;
+		INVALID_NAME,
+		OUT_OF_SPACE,
+		WRONG_USER,
+		NOT_CACHED,
+		REF_NOT_FOUND;
 		public static GLib.Quark quark ();
 	}
 	[CCode (cheader_filename = "flatpak.h", cprefix = "FLATPAK_PORTAL_ERROR_")]
@@ -386,4 +498,3 @@ namespace Flatpak {
 	[Version (since = "0.8")]
 	public static GLib.GenericArray<weak Flatpak.Installation> get_system_installations (GLib.Cancellable? cancellable = null) throws GLib.Error;
 }
-


### PR DESCRIPTION
Now that we have a newer version of Flatpak in the repos, we can do the download size calculation quicker and easier, so this adds a newly generated Flatpak vapi and takes advantage of the new method.