### PR TITLE
SuccessView: Make primary label format consistent

### DIFF
--- a/src/Views/SuccessView.vala
+++ b/src/Views/SuccessView.vala
@@ -38,9 +38,9 @@ public class Sideload.SuccessView : AbstractView {
 
         if (view_type == SuccessType.INSTALLED) {
             if (app_name != null) {
-                primary_label.label = _("“%s” was installed").printf (app_name);
+                primary_label.label = _("“%s” has been installed").printf (app_name);
             } else {
-                primary_label.label = _("The app was installed");
+                primary_label.label = _("The app has been installed");
             }
 
             secondary_label.label = _("Open it any time from the Applications Menu. Visit %s for app information, updates, and to uninstall. Permissions can be changed in <a href='%s'>%s → %s…</a>").printf (

--- a/src/Views/SuccessView.vala
+++ b/src/Views/SuccessView.vala
@@ -38,7 +38,7 @@ public class Sideload.SuccessView : AbstractView {
 
         if (view_type == SuccessType.INSTALLED) {
             if (app_name != null) {
-                primary_label.label = _("Installed “%s”").printf (app_name);
+                primary_label.label = _("“%s” was installed").printf (app_name);
             } else {
                 primary_label.label = _("The app was installed");
             }


### PR DESCRIPTION
Thinking about it, I think I like the way this looks better:

![Screenshot from 2020-09-01 11 50 42@2x](https://user-images.githubusercontent.com/7277719/91894058-ed867080-ec49-11ea-8f64-f673452e7e7c.png)
