### PR TITLE
Ensure we throw the error dialog in the GTK thread

### DIFF
--- a/src/FlatpakRefFile.vala
+++ b/src/FlatpakRefFile.vala
@@ -340,8 +340,10 @@ public class Sideload.FlatpakRefFile : Object {
             return true;
         }
 
+        var e_copy = e.copy ();
+
         Idle.add (() => {
-            installation_failed (e);
+            installation_failed (e_copy);
 
             return GLib.Source.REMOVE;
         });

--- a/src/FlatpakRefFile.vala
+++ b/src/FlatpakRefFile.vala
@@ -340,7 +340,12 @@ public class Sideload.FlatpakRefFile : Object {
             return true;
         }
 
-        installation_failed (e);
+        Idle.add (() => {
+            installation_failed (e);
+
+            return GLib.Source.REMOVE;
+        });
+
         return false;
     }
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -129,7 +129,7 @@ public class Sideload.MainWindow : Gtk.ApplicationWindow {
 
             stack.add (success_view);
             stack.visible_child = success_view;
-        } else if (!(error is Flatpak.Error.ABORTED)){
+        } else if (!(error is Flatpak.Error.ABORTED)) {
             var error_view = new ErrorView (error);
 
             stack.add (error_view);

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -129,7 +129,7 @@ public class Sideload.MainWindow : Gtk.ApplicationWindow {
 
             stack.add (success_view);
             stack.visible_child = success_view;
-        } else {
+        } else if (!(error is Flatpak.Error.ABORTED)){
             var error_view = new ErrorView (error);
 
             stack.add (error_view);


### PR DESCRIPTION
Fixes #96 
Fixes #104 

The flatpak operation_error is potentially thrown in a thread, so we have to wrap our signal to ensure any UI operations driven off the back of it don't cause a segfault.