### PR TITLE
SuccessView: DRY strings

### DIFF
--- a/src/Views/SuccessView.vala
+++ b/src/Views/SuccessView.vala
@@ -37,6 +37,7 @@ public class Sideload.SuccessView : AbstractView {
         var app = (Sideload.Application) GLib.Application.get_default ();
         var appstore_name = app.get_appstore_name ();
         var file = ((Sideload.MainWindow) app.active_window).file;
+        string? secondary_label_string;
 
         if (view_type == SuccessType.INSTALLED) {
             if (app_name != null) {
@@ -45,17 +46,8 @@ public class Sideload.SuccessView : AbstractView {
                 primary_label.label = _("The app has been installed");
             }
 
-            if (file is FlatpakRefFile) {
-                secondary_label.label = _("Open it any time from the Applications Menu. Visit %s for app information, updates, and to uninstall. Permissions can be changed in <a href='%s'>%s → %s…</a>").printf (
-                    /// TRANSLATORS: "System Settings" is related to the title of https://github.com/elementary/switchboard, "Applications" is related to the title of https://github.com/elementary/switchboard-plug-applications
-                    appstore_name, "settings://applications/permissions", _("System Settings"), _("Applications")
-                );
-            } else if (file is FlatpakBundleFile) {
-                secondary_label.label = _("Open it any time from the Applications Menu. Permissions can be changed in <a href='%s'>%s → %s…</a>").printf (
-                    /// TRANSLATORS: "System Settings" is related to the title of https://github.com/elementary/switchboard, "Applications" is related to the title of https://github.com/elementary/switchboard-plug-applications
-                    "settings://applications/permissions", _("System Settings"), _("Applications")
-                );
-            }
+            secondary_label_string = _("Open it any time from the Applications Menu.");
+
         } else if (view_type == SuccessType.ALREADY_INSTALLED) {
             if (app_name != null) {
                 primary_label.label = _("“%s” is already installed").printf (app_name);
@@ -63,18 +55,23 @@ public class Sideload.SuccessView : AbstractView {
                 primary_label.label = _("This app is already installed");
             }
 
-            if (file is FlatpakRefFile) {
-                secondary_label.label = _("No changes were made. Visit %s for app information, updates, and to uninstall. Permissions can be changed in <a href='%s'>%s → %s…</a>").printf (
-                    /// TRANSLATORS: "System Settings" is related to the title of https://github.com/elementary/switchboard, "Applications" is related to the title of https://github.com/elementary/switchboard-plug-applications
-                    appstore_name, "settings://applications/permissions", _("System Settings"), _("Applications")
-                );
-            } else if (file is FlatpakBundleFile) {
-                secondary_label.label = _("No changes were made. Permissions can be changed in <a href='%s'>%s → %s…</a>").printf (
-                    /// TRANSLATORS: "System Settings" is related to the title of https://github.com/elementary/switchboard, "Applications" is related to the title of https://github.com/elementary/switchboard-plug-applications
-                    "settings://applications/permissions", _("System Settings"), _("Applications")
-                );
-            }
+            secondary_label_string = _("No changes were made.");
         }
+
+        if (file is FlatpakRefFile) {
+            secondary_label_string += " ";
+            secondary_label_string += _("Visit %s for app information, updates, and to uninstall.").printf (
+                appstore_name
+            );
+        }
+
+        secondary_label_string += " ";
+        secondary_label_string += _("Permissions can be changed in <a href='%s'>%s → %s…</a>").printf (
+            /// TRANSLATORS: "System Settings" is related to the title of https://github.com/elementary/switchboard, "Applications" is related to the title of https://github.com/elementary/switchboard-plug-applications
+            "settings://applications/permissions", _("System Settings"), _("Applications")
+        );
+
+        secondary_label.label = secondary_label_string;
 
         var trash_check = new Gtk.CheckButton.with_label (_("Move ”%s” to Trash").printf (file.file.get_basename ()));
         content_area.add (trash_check);

--- a/src/Views/SuccessView.vala
+++ b/src/Views/SuccessView.vala
@@ -65,9 +65,9 @@ public class Sideload.SuccessView : AbstractView {
             );
         }
 
-        /// TRANSLATORS: "System Settings" is related to the title of https://github.com/elementary/switchboard, "Applications" is related to the title of https://github.com/elementary/switchboard-plug-applications
-        var settings_path = _("System Settings → Applications");
-        var link_markup = "<a href='%s'>%s…</a>".printf ("settings://applications/permissions", settings_path);
+        /// TRANSLATORS: "System Settings" is related to the title of https://github.com/elementary/switchboard, "Applications" is related to the title of https://github.com/elementary/switchboard-plug-applications. Note that this includes an ellipsis (…) in English to signify the action will be performed in a new window.
+        var settings_path = _("System Settings → Applications…");
+        var link_markup = "<a href='%s'>%s</a>".printf ("settings://applications/permissions", settings_path);
 
         secondary_label_string += " ";
         secondary_label_string += _("Permissions can be changed in %s").printf (link_markup);

--- a/src/Views/SuccessView.vala
+++ b/src/Views/SuccessView.vala
@@ -65,11 +65,12 @@ public class Sideload.SuccessView : AbstractView {
             );
         }
 
+        /// TRANSLATORS: "System Settings" is related to the title of https://github.com/elementary/switchboard, "Applications" is related to the title of https://github.com/elementary/switchboard-plug-applications
+        var settings_path = _("System Settings → Applications");
+        var link_markup = "<a href='%s'>%s…</a>".printf ("settings://applications/permissions", settings_path);
+
         secondary_label_string += " ";
-        secondary_label_string += _("Permissions can be changed in <a href='%s'>%s → %s…</a>").printf (
-            /// TRANSLATORS: "System Settings" is related to the title of https://github.com/elementary/switchboard, "Applications" is related to the title of https://github.com/elementary/switchboard-plug-applications
-            "settings://applications/permissions", _("System Settings"), _("Applications")
-        );
+        secondary_label_string += _("Permissions can be changed in %s").printf (link_markup);
 
         secondary_label.label = secondary_label_string;
 


### PR DESCRIPTION
This started as a review comment but since I touched so much I figured I'd pull it out into a PR against @Marukesu's PR. This branch removes repetition of strings from the success view, breaking them up into their own individually-translated strings and the concatenating them together (with spaces). Does this make sense?

I originally tried using `String.join ()` but it just seemed to really over-complicate things. I also considered `printf ()`, but we don't know the number of strings being concatenated so that didn't seem to make sense.