### PR TITLE
MainWindow: Draggable Window

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ You'll need the following dependencies:
 * libflatpak-dev
 * libgranite-dev (>=5.4.0)
 * libgtk-3-dev
+* libhandy-1-dev
 * libxml2-dev
 * meson
 * valac

--- a/meson.build
+++ b/meson.build
@@ -31,6 +31,7 @@ executable(
         dependency ('gobject-2.0'),
         dependency ('granite', version: '>=5.4.0'),
         dependency ('gtk+-3.0'),
+        dependency ('libhandy-1'),
         dependency ('libxml-2.0'),
     ],
     install : true

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -18,7 +18,7 @@
 *
 */
 
-public class Sideload.MainWindow : Gtk.ApplicationWindow {
+public class Sideload.MainWindow : Hdy.ApplicationWindow {
     public FlatpakFile file { get; construct; }
     private Cancellable? current_cancellable = null;
 
@@ -39,9 +39,9 @@ public class Sideload.MainWindow : Gtk.ApplicationWindow {
     }
 
     construct {
-        var titlebar = new Gtk.HeaderBar ();
-        titlebar.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
-        titlebar.set_custom_title (new Gtk.Grid ());
+        Hdy.init ();
+
+        var window_handle = new Hdy.WindowHandle ();
 
         var image = new Gtk.Image.from_icon_name ("io.elementary.sideload", Gtk.IconSize.DIALOG);
         image.valign = Gtk.Align.START;
@@ -60,9 +60,8 @@ public class Sideload.MainWindow : Gtk.ApplicationWindow {
         stack.add (main_view);
         stack.add (progress_view);
 
-        add (stack);
-        get_style_context ().add_class ("rounded");
-        set_titlebar (titlebar);
+        window_handle.add (stack);
+        add (window_handle);
 
         main_view.install_request.connect (on_install_button_clicked);
         file.progress_changed.connect (on_progress_changed);


### PR DESCRIPTION
Use `Hdy.ApplicationWindow` and `Hdy.WindowHandle` to allow the window be draggable from anywhere.

FIxes #119.