### PR TITLE
Handle error on constructing flatpak bundle, fix error signalling

### DIFF
--- a/src/FlatpakBundleFile.vala
+++ b/src/FlatpakBundleFile.vala
@@ -33,7 +33,9 @@ public class Sideload.FlatpakBundleFile : FlatpakFile {
             size = GLib.format_size (bundle.get_installed_size ());
             has_remote = bundle.get_origin () != null;
         } catch (Error e) {
-            warning (e.message);
+            size = "0";
+            error_code = Flatpak.Error.INVALID_REF;
+            error_message = _("Error constructing Flatpak bundle: %s").printf (e.message);
         }
     }
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -51,6 +51,13 @@ public class Sideload.MainWindow : Gtk.ApplicationWindow {
             vhomogeneous = false
         };
         stack.add_child (main_view);
+        stack.visible_child = main_view;
+
+        var window_handle = new Gtk.WindowHandle () {
+            child = stack
+        };
+
+        child = window_handle;
 
         if (file.size == "0") {
             var error_view = new ErrorView (file.error_code, file.error_message);
@@ -65,12 +72,6 @@ public class Sideload.MainWindow : Gtk.ApplicationWindow {
         }
 
         stack.add_child (progress_view);
-
-        var window_handle = new Gtk.WindowHandle () {
-            child = stack
-        };
-
-        child = window_handle;
 
         // We need to hide the title area
         var null_title = new Gtk.Grid () {
@@ -154,7 +155,6 @@ public class Sideload.MainWindow : Gtk.ApplicationWindow {
                 stack.visible_child = success_view;
                 break;
 
-// <<<<<<< HEAD
             case Flatpak.Error.ABORTED:
                 break;
 
@@ -164,15 +164,6 @@ public class Sideload.MainWindow : Gtk.ApplicationWindow {
                 stack.visible_child = error_view;
 
                 break;
-// =======
-//             stack.add_child (success_view);
-//             stack.visible_child = success_view;
-//         } else if (!(error is Flatpak.Error.ABORTED)) {
-//             var error_view = new ErrorView (error);
-
-//             stack.add_child (error_view);
-//             stack.visible_child = error_view;
-// >>>>>>> master
         }
 
         if (file is FlatpakRefFile) {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -59,6 +59,30 @@ public class Sideload.MainWindow : Gtk.ApplicationWindow {
 
         child = window_handle;
 
+        // We need to hide the title area
+        var null_title = new Gtk.Grid () {
+            visible = false
+        };
+        set_titlebar (null_title);
+
+        add_css_class ("dialog");
+        add_css_class (Granite.STYLE_CLASS_MESSAGE_DIALOG);
+
+        var granite_settings = Granite.Settings.get_default ();
+        var gtk_settings = Gtk.Settings.get_default ();
+
+        gtk_settings.gtk_application_prefer_dark_theme = granite_settings.prefers_color_scheme == Granite.Settings.ColorScheme.DARK;
+
+        granite_settings.notify["prefers-color-scheme"].connect (() => {
+            gtk_settings.gtk_application_prefer_dark_theme = granite_settings.prefers_color_scheme == Granite.Settings.ColorScheme.DARK;
+        });
+
+        GLib.Application.get_default ().shutdown.connect (() => {
+            if (current_cancellable != null) {
+                current_cancellable.cancel ();
+            }
+        });
+
         if (file.size == "0") {
             var error_view = new ErrorView (file.error_code, file.error_message);
             stack.add_child (error_view);
@@ -72,15 +96,6 @@ public class Sideload.MainWindow : Gtk.ApplicationWindow {
         }
 
         stack.add_child (progress_view);
-
-        // We need to hide the title area
-        var null_title = new Gtk.Grid () {
-            visible = false
-        };
-        set_titlebar (null_title);
-
-        add_css_class ("dialog");
-        add_css_class (Granite.STYLE_CLASS_MESSAGE_DIALOG);
 
         main_view.install_request.connect (on_install_button_clicked);
         file.progress_changed.connect (on_progress_changed);
@@ -101,22 +116,7 @@ public class Sideload.MainWindow : Gtk.ApplicationWindow {
             }
         });
 
-        var granite_settings = Granite.Settings.get_default ();
-        var gtk_settings = Gtk.Settings.get_default ();
-
-        gtk_settings.gtk_application_prefer_dark_theme = granite_settings.prefers_color_scheme == Granite.Settings.ColorScheme.DARK;
-
-        granite_settings.notify["prefers-color-scheme"].connect (() => {
-            gtk_settings.gtk_application_prefer_dark_theme = granite_settings.prefers_color_scheme == Granite.Settings.ColorScheme.DARK;
-        });
-
         get_details.begin ();
-
-        GLib.Application.get_default ().shutdown.connect (() => {
-            if (current_cancellable != null) {
-                current_cancellable.cancel ();
-            }
-        });
     }
 
     private async void get_details () {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -142,7 +142,6 @@ public class Sideload.MainWindow : Hdy.ApplicationWindow {
         switch (error_code) {
             case Flatpak.Error.ALREADY_INSTALLED:
                 var success_view = new SuccessView (app_name, SuccessView.SuccessType.ALREADY_INSTALLED);
-
                 stack.add (success_view);
                 stack.visible_child = success_view;
                 break;

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -47,17 +47,17 @@ public class Sideload.MainWindow : Hdy.ApplicationWindow {
         image.valign = Gtk.Align.START;
 
         main_view = new MainView ();
+        stack = new Gtk.Stack () {
+            vhomogeneous = false
+        };
+        stack.add (main_view);
+        window_handle.add (stack);
+        add (window_handle);
 
         if (file.size == "0") {
             var error_view = new ErrorView (file.error_code, file.error_message);
-            stack = new Gtk.Stack ();
-            stack.vhomogeneous = false;
-            stack.add (main_view);
             stack.add (error_view);
             stack.visible_child = error_view;
-            window_handle.add (stack);
-            add (window_handle);
-
             return;
         } else if (file is FlatpakRefFile) {
             progress_view = new ProgressView (ProgressView.ProgressType.REF_INSTALL);
@@ -66,13 +66,7 @@ public class Sideload.MainWindow : Hdy.ApplicationWindow {
             progress_view.status = (_("Installing %s. Unable to estimate time remaining.")).printf (file.size);
         }
 
-        stack = new Gtk.Stack ();
-        stack.vhomogeneous = false;
-        stack.add (main_view);
         stack.add (progress_view);
-
-        window_handle.add (stack);
-        add (window_handle);
 
         main_view.install_request.connect (on_install_button_clicked);
         file.progress_changed.connect (on_progress_changed);

--- a/src/Views/ErrorView.vala
+++ b/src/Views/ErrorView.vala
@@ -16,10 +16,14 @@
  */
 
 public class Sideload.ErrorView : AbstractView {
-    public GLib.Error error { get; construct; }
+    public int error_code { get; construct; }
+    public string error_message { get; construct; }
 
-    public ErrorView ( GLib.Error error) {
-        Object (error: error);
+    public ErrorView (int error_code, string? error_message) {
+        Object (
+            error_code: error_code,
+            error_message: error_message
+        );
     }
 
     construct {
@@ -27,11 +31,11 @@ public class Sideload.ErrorView : AbstractView {
 
         primary_label.label = _("Install failed");
 
-        secondary_label.label = prettify_flatpak_error (error);
+        secondary_label.label = prettify_flatpak_error (error_code, error_message);
 
         var details_view = new Gtk.TextView ();
         details_view.border_width = 6;
-        details_view.buffer.text = error.message;
+        details_view.buffer.text = error_message;
         details_view.editable = false;
         details_view.pixels_below_lines = 3;
         details_view.wrap_mode = Gtk.WrapMode.WORD;
@@ -55,35 +59,35 @@ public class Sideload.ErrorView : AbstractView {
         show_all ();
     }
 
-    private static string prettify_flatpak_error (GLib.Error e) {
-        if (e is Flatpak.Error.ALREADY_INSTALLED) {
-            return _("This app is already installed.");
+    private static string prettify_flatpak_error (int error_code, string? error_message) {
+        if (error_code >= 0) {
+            switch (error_code) {
+                case Flatpak.Error.ALREADY_INSTALLED:
+                    return _("This app is already installed.");
+
+                case Flatpak.Error.NEED_NEW_FLATPAK:
+                    return _("A newer version of Flatpak is needed to install this app.");
+
+                case Flatpak.Error.REMOTE_NOT_FOUND:
+                    return _("A required Flatpak remote was not found.");
+
+                case Flatpak.Error.RUNTIME_NOT_FOUND:
+                    return _("A required runtime dependency could not be found.");
+
+                case Flatpak.Error.INVALID_REF:
+                    return _("The supplied .flatpakref file does not seem to be valid.");
+
+                case Flatpak.Error.UNTRUSTED:
+                    return _("The app is not signed with a trusted signature.");
+
+                case Flatpak.Error.INVALID_NAME:
+                    return _("The application, runtime, or remote name is invalid.");
+
+                default:
+                    break; //TODO Check and handle other errors
+            }
         }
 
-        if (e is Flatpak.Error.NEED_NEW_FLATPAK) {
-            return _("A newer version of Flatpak is needed to install this app.");
-        }
-
-        if (e is Flatpak.Error.REMOTE_NOT_FOUND) {
-            return _("A required Flatpak remote was not found.");
-        }
-
-        if (e is Flatpak.Error.RUNTIME_NOT_FOUND) {
-            return _("A required runtime dependency could not be found.");
-        }
-
-        if (e is Flatpak.Error.INVALID_REF) {
-            return _("The supplied .flatpakref file does not seem to be valid.");
-        }
-
-        if (e is Flatpak.Error.UNTRUSTED) {
-            return _("The app is not signed with a trusted signature.");
-        }
-
-        if (e is Flatpak.Error.INVALID_NAME) {
-            return _("The application, runtime, or remote name is invalid.");
-        }
-
-        return _("An unknown error occured.");
+        return error_message ?? _("An unknown error occurred.");
     }
 }

--- a/src/Views/ErrorView.vala
+++ b/src/Views/ErrorView.vala
@@ -82,9 +82,6 @@ public class Sideload.ErrorView : AbstractView {
 
                 case Flatpak.Error.INVALID_NAME:
                     return _("The application, runtime, or remote name is invalid.");
-
-                default:
-                    break; //TODO Check and handle other errors
             }
         }
 


### PR DESCRIPTION
Fixes #136 

When the bundle is created, the size is checked, if "0" this is an indication of an error and the error code and message are used to show an ErrorView.  Two new FlatpakFile properties had to be introduced as signalling or throwing an error from a constructor is not possible (afaik).

Problems occur when passing error types as parameters of signals for some reason so instead fundamental types (int, string) are passed instead.
